### PR TITLE
Draft: convert fid files (only fileheader) to json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,8 @@ dist
 
 lib
 lib-esm
+
+# for typedoc tests
+.docs
+# tests snapshots
+__snapshots__

--- a/FORMAT.md
+++ b/FORMAT.md
@@ -1,0 +1,34 @@
+# Varian NMR, fid format
+
+
+Varian/Agilent instruments store data in different files under a directory ending in '.fid'. Inside this directory, there is all the data in files:
+
+* **fid**: fid binary data.
+* **procpar**: fid params, settings. ASCII.
+* **text**: text file.
+
+**fid** file stores experiment's parameters **and** the FIDs **or** NMR spectral data. (this may not
+be true, is my interpretation so far).
+
+The FID is the precession of the z-axis spin's magnetic moment over time, which is fourier transformed to get
+the spectral data. FIDs are stored as 16 or 32 bit integers. The fourier transformed data is in
+32bit floating point numbers.
+
+**procpar** some parameters should be always taken from **fid** file, because they could have changed after measurement was taken. (for example after compresison fid will indicate 16bits and procpar 32bits). The procpar are the parameters set in the software to perform the measurements, but not necessarily the **data** on disk. There are however, important values that are the same, and we can safely scrape out. 
+
+It's necessary to read the binary file to determine data structure and type, probably use some
+properties from the procedure-parameters file. In particular about _experimental conditions and the variables controlling the pulse sequence._
+
+The **C** object structures allow to map the bits to `property:value` pairs. Once parsed, the information can be displayed as a JSON object in the JS code.
+
+* Fileheader (first 32B): Holds Important metadata about the file. This is, the number of blocks,
+  size of blocks etc. For fid files holding FIDs - and not transformed spectras, the number of block
+  headers is 1.
+* BlockHeader (28B): Holds Important metadata about the block.
+
+The general structure of those headers is different, but they share some properties (example
+[Status class, under utils](./src/utils).)
+
+
+## Reads
+* [Free Induction Decay FID Wiki](https://en.wikipedia.org/wiki/Free_induction_decay).

--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@ Load and parse varian NMR native format.
 ## Usage
 
 ```js
-import { myModule } from 'varian-converter';
+import {readFileSync} from 'fs';
+import {join} from 'path';
 
-const result = myModule(args);
-// result is ...
+import { convert } from 'varian-converter';
+
+const fidFile = readFileSync(join(__dirname, "path/to/dir.fid/fid")) 
+const result = convert(fidFile); /* json with all the data converted from the binary source. */
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.3",
     "typescript": "^4.5.4"
+  },
+  "dependencies": {
+    "iobuffer": "^5.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.3",
-    "typescript": "^4.5.4"
+    "typescript": "^4.5.5"
   },
   "dependencies": {
     "iobuffer": "^5.1.0"

--- a/src/__tests__/convert.test.ts
+++ b/src/__tests__/convert.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { convert } from '../convert';
+
+describe('convert fid file for protons', () => {
+  it('proton.fid', () => {
+    const fid = readFileSync(join(__dirname, '../../data/proton.fid/fid'));
+    const result = convert(fid);
+    expect(Object.keys(result.fileHeader)).toHaveLength(9);
+    expect(result).toMatchSnapshot();
+    // we have another parser that should give a pretty similar result
+  });
+});

--- a/src/__tests__/readFileHeader.test.ts
+++ b/src/__tests__/readFileHeader.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { IOBuffer } from 'iobuffer';
+
+import { FileHeader } from '../readFileHeader';
+
+const file = readFileSync(join(__dirname, '../../data/proton.fid/fid'));
+let buffer = new IOBuffer(file);
+
+describe('read the file header', () => {
+  it('cross validate values in the header', () => {
+    const fileHeader = new FileHeader(buffer);
+    // console.log(fileHeader);
+    /* values we test */
+    const { eBytes, np, tBytes, nTraces, bBytes, nBlockHeaders } = fileHeader;
+
+    const numberOfBytesInTrace = eBytes * np;
+    const numberOfBytesInDataBlock =
+      numberOfBytesInTrace * nTraces + nBlockHeaders * 28;
+
+    expect(numberOfBytesInTrace).toBe(tBytes);
+    expect(numberOfBytesInDataBlock).toBe(bBytes);
+  });
+});

--- a/src/__tests__/test.ts
+++ b/src/__tests__/test.ts
@@ -1,7 +1,0 @@
-import { myModule } from '..';
-
-describe('test myModule', () => {
-  it('should return 42', () => {
-    expect(myModule()).toBe(42);
-  });
-});

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,0 +1,26 @@
+import { FileStatus } from '../utils';
+
+test('inspect bits', () => {
+  /*
+   * to see how bits are inspected, just invent
+   * a number and check the props.
+   */
+  const status = new FileStatus(0b00000110010101);
+  /* the number means: stores data, in int32 form,
+and it is complex, etc */
+  expect(status).toMatchObject({
+    storesData: true,
+    isSpectrum: false,
+    isInt32: true,
+    isFloat: false,
+    isComplex: true,
+    isHypercomplex: false,
+    isAcqPar: true,
+    isSecondFT: true,
+    isTransformed: false,
+    isNp: false,
+    isNf: false,
+    isNi: false,
+    isNi2: false,
+  });
+});

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,0 +1,27 @@
+import { IOBuffer } from 'iobuffer';
+
+import { FileHeader } from './readFileHeader';
+
+/**
+ * varian-convert takes a `fid` input file as a buffer or array buffer
+ * and retrieves an object storing all metadata, data and information from the
+ * original `fid` file.
+ */
+
+export interface Fid {
+  /** first block - header - of the fid file. Stores important file metadata.*/
+  fileHeader: FileHeader;
+}
+/**
+ * converts a fid file to JSON object
+ *
+ * @param data fid file
+ * @return Object containing all the parsed information from the fid file
+ */
+export function convert(data: Buffer | ArrayBuffer): Fid {
+  /* function will return the whole thing */
+  const buffer = new IOBuffer(data);
+  const fileHeader = new FileHeader(buffer);
+
+  return { fileHeader };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,3 @@
-/**
- * My module
- * @returns A very important number
- */
-export function myModule(): number {
-  return 42;
-}
+export * from './convert';
+export * from './readFileHeader';
+export * from './utils';

--- a/src/readFileHeader.ts
+++ b/src/readFileHeader.ts
@@ -1,0 +1,47 @@
+import { IOBuffer } from 'iobuffer';
+
+import { FileStatus } from './utils';
+
+/**
+ * File Header parsing - First 32 bytes. The file header is the first block of the file
+ * It stores relevant properties i.e size and number of other blocks etc.
+ * @param buffer fid iobuffer i.e `new IOBuffer(buffer)`
+ * @return Metadata
+ */
+export class FileHeader {
+  /** number of data blocks in the file */
+  public nBlocks: number;
+  /** number of FID "traces" per block (high resolution spectra with "nf=1" have one FID / "trace" per block, multi-echo FIDs such as imaging FIDs acquired in "compressed" mode may have multiple FIDs / "traces" per block) */
+  public nTraces: number;
+  /** number of (real, not complex) meaningful (data) points per "trace" (typically equal to the "np" parameter), */
+  public np: number;
+  /** number of bytes per "element"/point (precision). 2 for 16-bit data (dp='n'), 4 for 32-bit data (dp='y').  */
+  public eBytes: number;
+  /** trace bytes i.e., fheader.ebytes * fheader.np */
+  public tBytes: number;
+  /** block bytes, in "C speak": fheader.ebytes * fheader.np * fheader.ntraces +
+          sizeof(struct blockHeader) i.e 28B */
+  public bBytes: number;
+  /** VnmrJ version ID (you may find this set to zero - it's not really used in our software); */
+  public versionId: number;
+  /** status of the data */
+  public status: FileStatus;
+  public nBlockHeaders: number;
+  public constructor(buffer: IOBuffer) {
+    /* Set big endian to read numbers the other way around */
+    buffer.setBigEndian();
+
+    /* make sure the offset is 0 to read the file header */
+    buffer.offset = 0;
+
+    this.nBlocks = buffer.readUint32();
+    this.nTraces = buffer.readUint32();
+    this.np = buffer.readUint32();
+    this.eBytes = buffer.readUint32();
+    this.tBytes = buffer.readUint32();
+    this.bBytes = buffer.readUint32();
+    this.versionId = buffer.readUint16();
+    this.status = new FileStatus(buffer.readUint16());
+    this.nBlockHeaders = buffer.readUint32();
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,62 @@
+/**
+ * Status of the data stored. Used in block headers and file header.
+ * The value of "status" is a flag.
+ * @param status pass the code
+ * @return status object with important information about the block data.
+ */
+export class Status {
+  /** - 0x1 indicates the presence of data */
+  public storesData: boolean;
+  /** 0x2 would indicate "spectrum" (as opposed to "FID") */
+  public isSpectrum: boolean;
+  /** 0x4 indicates 32-bit (as opposed to 16-bit) data */
+  public isInt32: boolean;
+  /** 0x8 indicates (32-bit, IEEE format) floating point data (**then bit 2 is irrelevant**) */
+  public isFloat: boolean;
+  /** 0x10 indicates complex (as opposed to real) data */
+  public isComplex: boolean;
+  /** 0x20 indicates hypercomplex data (transformed nD data only) */
+  public isHypercomplex: boolean;
+  /** 0x40 is unused up to VnmrJ 1.1D */
+  public constructor(status: number) {
+    this.storesData = (status & 0x1) !== 0;
+    this.isSpectrum = (status & 0x2) !== 0;
+    this.isInt32 = (status & 0x4) !== 0;
+    this.isFloat = (status & 0x8) !== 0;
+    this.isComplex = (status & 0x10) !== 0;
+    this.isHypercomplex = (status & 0x20) !== 0;
+  }
+}
+
+/**
+ * File status bits.
+ * @extends [[`Status`]]
+ * @param status pass the code
+ * @return status object with important information about the block data.
+ */
+export class FileStatus extends Status {
+  /** 0x80. Not sure what Acquisition Parameters means yet */
+  public isAcqPar: boolean;
+  /** 0x100. 0 means is first FT, 1 is second */
+  public isSecondFT: boolean;
+  /** 0x200. 0 regular, 1 transposed */
+  public isTransformed: boolean;
+  /** 0x800. np dimension is active */
+  public isNp: boolean;
+  /** 0x1000. nf dimension is active */
+  public isNf: boolean;
+  /** 0x2000. ni dimension is active */
+  public isNi: boolean;
+  /** 0x4000. n2 dimension is active */
+  public isNi2: boolean;
+  public constructor(status: number) {
+    super(status);
+    this.isAcqPar = (status & 0x80) !== 0;
+    this.isSecondFT = (status & 0x100) !== 0;
+    this.isTransformed = (status & 0x200) !== 0;
+    this.isNp = (status & 0x800) !== 0;
+    this.isNf = (status & 0x1000) !== 0;
+    this.isNi = (status & 0x2000) !== 0;
+    this.isNi2 = (status & 0x4000) !== 0;
+  }
+}


### PR DESCRIPTION
Hi there, 

Here I write a summary of changes, and a 'styling' question at the bottom.

* Takes the fid binary file and returns a json object (for now just header, I'm working in the rest), there are tests for each ts file.
* The docs were tested created fine (ignored in the `.gitignore` for PRs)
* Simple readme.md for usage reference, and a format.md describing each detail for how to parse the file (at least part of it is in big endian format)

There are many config files that make reading the folder a bit difficult. Would it be fine to update the generator, or at least this project, such that all the config files are either under `./config` or `./.config`? Not a big deal anyways, I just saw it defined like that in typedoc repository itself (I believe), and thought it a good idea.
 